### PR TITLE
Fix incorrect handling of string encoding

### DIFF
--- a/TinyCborObjc/cbortojson_nsstring.m
+++ b/TinyCborObjc/cbortojson_nsstring.m
@@ -437,7 +437,8 @@ static CborError map_to_json(NSMutableString *out, CborValue *it, int flags, Con
             return err;
 
         /* first, print the key */
-        [out appendFormat:@"\"%s\":", key];
+        NSString *utf8Key = [[NSString alloc] initWithCString:key encoding:NSUTF8StringEncoding];
+        [out appendFormat:@"\"%@\":", utf8Key];
 
         /* then, print the value */
         CborType valueType = cbor_value_get_type(it);
@@ -446,10 +447,10 @@ static CborError map_to_json(NSMutableString *out, CborValue *it, int flags, Con
         /* finally, print any metadata we may have */
         if (flags & CborConvertAddMetadata) {
             if (!err && keyType != CborTextStringType) {
-                [out appendFormat:@",\"%s$keycbordump\":true", key];
+                [out appendFormat:@",\"%@$keycbordump\":true", utf8Key];
             }
             if (!err && status->flags) {
-                [out appendFormat:@",\"%s$cbor\":{", key];
+                [out appendFormat:@",\"%@$cbor\":{", utf8Key];
                 if (add_value_metadata(out, valueType, status) != CborNoError ||
                     putc_to_nsstring('}', out) < 0)
                     err = CborErrorIO;
@@ -533,11 +534,14 @@ static CborError value_to_json(NSMutableString *out, CborValue *it, int flags, C
         }
         if (err)
             return err;
+
+        NSString *utf8Str = [[NSString alloc] initWithCString:str encoding:NSUTF8StringEncoding];
+
         if (type == CborByteStringType) {
-            [out appendFormat:@"\"%@%s\"", DSCborBase64DataMarker, str];
+            [out appendFormat:@"\"%@%@\"", DSCborBase64DataMarker, utf8Str];
         }
         else {
-            [out appendFormat:@"\"%s\"", str];
+            [out appendFormat:@"\"%@\"", utf8Str];
         }
         err = CborNoError;
         free(str);

--- a/TinyCborObjcTests/DSCborDecodingTests.m
+++ b/TinyCborObjcTests/DSCborDecodingTests.m
@@ -28,6 +28,19 @@
     XCTAssertNil(error);
 }
 
+- (void)testEncodingAndDecodingADictionaryWithNonAsciiKeys {
+    NSDictionary<NSString *, NSString *> *dict = @{
+                                                   @"£test£": @"¡€#¢•©˙∆åßƒ∫~µç≈Ω"
+                                                   };
+    NSData *encoded = [dict ds_cborEncodedObject];
+    XCTAssertNotNil(encoded);
+    
+    NSError *error = nil;
+    id decoded = [encoded ds_decodeCborError:&error];
+    XCTAssertEqualObjects(decoded, dict);
+    XCTAssertNil(error);
+}
+
 - (void)testDictionaryDecoding {
     NSData *data = DATABYTES(0xA1, 0x63, 0x61, 0x62, 0x63, 0x18, 0x2A);
     NSError *error = nil;


### PR DESCRIPTION
Author: @hamchapman 

---

# Problem

Strings in the CBOR to JSON conversion code were being appended to the `out` string using `appendFormat` with the `%s` format specifier. This does not guarantee that UTF8 will be used as the encoding and it will in fact use whatever encoding is the default on the device that is running the code. On macOS, for most users, this will in fact be macOS Roman, which leads to things like `£` characters (anything that's over one byte in UTF8, really) being appended to the `out` string incorrectly, because they're appended using the wrong encoding.

# Solution

Explicitly use UTF8 encoding in the CBOR to JSON conversion code.