### PR TITLE
Allow decoding CBOR primitives

### DIFF
--- a/TinyCborObjc/NSData+DSCborDecoding.m
+++ b/TinyCborObjc/NSData+DSCborDecoding.m
@@ -64,7 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSData *jsonData = [jsonString dataUsingEncoding:NSUTF8StringEncoding];
     NSError *jsonError = nil;
     id parsedData = [NSJSONSerialization JSONObjectWithData:jsonData
-                                                    options:NSJSONReadingMutableContainers
+                                                    options:NSJSONReadingMutableContainers | NSJSONReadingFragmentsAllowed
                                                       error:&jsonError];
     [self convertBase64DataToNSData:parsedData];
     if (jsonError != nil && error != NULL) {


### PR DESCRIPTION
Author: @hamchapman 

---

# Problem

The `NSJSONReadingFragmentsAllowed` option wasn't used when decoding JSON and so individual values couldn't be decoded.

# Solution

Add the `NSJSONReadingFragmentsAllowed` JSON reading option to the instance of JSON decoding.