### PR TITLE
Fix various header import issues

### DIFF
--- a/TinyCborObjc/NSData+DSCborDecoding.m
+++ b/TinyCborObjc/NSData+DSCborDecoding.m
@@ -17,7 +17,7 @@
 
 #import "NSData+DSCborDecoding.h"
 
-#import <tinycbor/cbor.h>
+#import "cbor.h"
 
 #import "cbortojson_nsstring.h"
 

--- a/TinyCborObjc/NSData+DSCborDecoding.m
+++ b/TinyCborObjc/NSData+DSCborDecoding.m
@@ -16,10 +16,9 @@
 //
 
 #import "NSData+DSCborDecoding.h"
-
-#import "cbor.h"
-
 #import "cbortojson_nsstring.h"
+
+#import <tinycbor/cbor.h>
 
 NSString *const DSTinyCborDecodingErrorDomain = @"org.dash.tinycbor.decoding-error";
 

--- a/TinyCborObjc/NSObject+DSCborEncoding.m
+++ b/TinyCborObjc/NSObject+DSCborEncoding.m
@@ -17,7 +17,7 @@
 
 #import "NSObject+DSCborEncoding.h"
 
-#import <tinycbor/cbor.h>
+#import "cbor.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/TinyCborObjc/NSObject+DSCborEncoding.m
+++ b/TinyCborObjc/NSObject+DSCborEncoding.m
@@ -17,7 +17,7 @@
 
 #import "NSObject+DSCborEncoding.h"
 
-#import "cbor.h"
+#import <tinycbor/cbor.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/TinyCborObjc/cbortojson_nsstring.h
+++ b/TinyCborObjc/cbortojson_nsstring.h
@@ -25,8 +25,8 @@
 #ifndef CBORJSON_H
 #define CBORJSON_H
 
-#import <tinycbor/cbor.h>
-#import <Foundation/NSData.h>
+#import "cbor.h"
+#import <Foundation/Foundation.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/TinyCborObjc/cbortojson_nsstring.h
+++ b/TinyCborObjc/cbortojson_nsstring.h
@@ -25,7 +25,8 @@
 #ifndef CBORJSON_H
 #define CBORJSON_H
 
-#import "cbor.h"
+#import <tinycbor/cbor.h>
+
 #import <Foundation/Foundation.h>
 
 #ifdef __cplusplus

--- a/TinyCborObjc/cbortojson_nsstring.m
+++ b/TinyCborObjc/cbortojson_nsstring.m
@@ -30,18 +30,17 @@
 #  define __STDC_LIMIT_MACROS 1
 #endif
 
-#include <tinycbor/cbor.h>
-#include <tinycbor/cborjson.h>
-#include <tinycbor/cborinternal_p.h>
-#include <tinycbor/compilersupport_p.h>
+#include "cbor.h"
+#include "cborjson.h"
+#include "cborinternal_p.h"
+#include "compilersupport_p.h"
 
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#import <Foundation/NSData.h>
-#import <Foundation/NSString.h>
+#import <Foundation/Foundation.h>
 
 NSString * const DSCborBase64DataMarker = @"___DS_CBOR_BASE64___";
 

--- a/TinyCborObjc/cbortojson_nsstring.m
+++ b/TinyCborObjc/cbortojson_nsstring.m
@@ -30,10 +30,10 @@
 #  define __STDC_LIMIT_MACROS 1
 #endif
 
-#include "cbor.h"
-#include "cborjson.h"
-#include "cborinternal_p.h"
-#include "compilersupport_p.h"
+#include <tinycbor/cbor.h>
+#include <tinycbor/cborjson.h>
+#include <tinycbor/cborinternal_p.h>
+#include <tinycbor/compilersupport_p.h>
 
 #include <inttypes.h>
 #include <stdio.h>


### PR DESCRIPTION
Author: @hamchapman 

---

# Problems

- There was a missing import of `NSString`.
- ~The imports assumed certain placement of the tinycbor dependency, which wasn't suitable for how it was setup for Ditto's usage.~

# Solutions
- Replace fine-graine Foundation imports with the canonical umbrella `Foundation/Foundation.h` header import in `cbortojson_nsstring.m`.
- ~Change imports to just `cbor.h`, where necessary.~