### PR TITLE
Problem: We could not encode non-Foundation objects

### DIFF
--- a/ObjCCBOR.xcodeproj/project.pbxproj
+++ b/ObjCCBOR.xcodeproj/project.pbxproj
@@ -9,6 +9,10 @@
 /* Begin PBXBuildFile section */
 		3720B70F245186FB005B9C8D /* NSObject+ObjCCBOR.m in Sources */ = {isa = PBXBuildFile; fileRef = 3720B709245186FB005B9C8D /* NSObject+ObjCCBOR.m */; };
 		3720B710245186FB005B9C8D /* cbortojson_nsstring.m in Sources */ = {isa = PBXBuildFile; fileRef = 3720B70A245186FB005B9C8D /* cbortojson_nsstring.m */; };
+		37388129245ACE4900BADA35 /* TestHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 37388128245ACE4900BADA35 /* TestHelpers.m */; };
+		37388130245C875C00BADA35 /* ObjCCBOR.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3738812F245C86EB00BADA35 /* ObjCCBOR.h */; };
+		37388133245C898200BADA35 /* CBOR.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = D26CE68424502F5E00B8A91A /* CBOR.h */; };
+		37388135245C89E100BADA35 /* CBORRepresentable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 37388126245AC82200BADA35 /* CBORRepresentable.h */; };
 		3762E843240FFAA100D823DC /* EncodingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3762E840240FFAA100D823DC /* EncodingTests.m */; };
 		3762E844240FFAA100D823DC /* DecodingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3762E841240FFAA100D823DC /* DecodingTests.m */; };
 		D26CE65E24502C2700B8A91A /* cbortojson.c in Sources */ = {isa = PBXBuildFile; fileRef = 3762E890240FFBD400D823DC /* cbortojson.c */; };
@@ -27,8 +31,7 @@
 		D26CE66C24502C5400B8A91A /* tinycbor-version.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3762E891240FFBD400D823DC /* tinycbor-version.h */; };
 		D26CE66D24502C5600B8A91A /* compilersupport_p.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3762E892240FFBD400D823DC /* compilersupport_p.h */; };
 		D26CE67124502D0E00B8A91A /* cborinternal_p.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3762E8A2240FFBD400D823DC /* cborinternal_p.h */; };
-		D26CE68624502F5E00B8A91A /* ObjCCBOR.m in Sources */ = {isa = PBXBuildFile; fileRef = D26CE68524502F5E00B8A91A /* ObjCCBOR.m */; };
-		D26CE68724502F5E00B8A91A /* ObjCCBOR.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = D26CE68424502F5E00B8A91A /* ObjCCBOR.h */; };
+		D26CE68624502F5E00B8A91A /* CBOR.m in Sources */ = {isa = PBXBuildFile; fileRef = D26CE68524502F5E00B8A91A /* CBOR.m */; };
 		D26CE68C24502F8300B8A91A /* NSData+ObjCCBOR.m in Sources */ = {isa = PBXBuildFile; fileRef = D26CE649244FCA9400B8A91A /* NSData+ObjCCBOR.m */; };
 		D26CE68E24502F9C00B8A91A /* libtinycbor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D26CE65524502BF300B8A91A /* libtinycbor.a */; };
 		D26CE6932450301A00B8A91A /* libObjCCBOR.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D26CE68224502F5E00B8A91A /* libObjCCBOR.a */; };
@@ -73,7 +76,9 @@
 			dstPath = "include/$(PRODUCT_NAME)";
 			dstSubfolderSpec = 16;
 			files = (
-				D26CE68724502F5E00B8A91A /* ObjCCBOR.h in CopyFiles */,
+				37388135245C89E100BADA35 /* CBORRepresentable.h in CopyFiles */,
+				37388133245C898200BADA35 /* CBOR.h in CopyFiles */,
+				37388130245C875C00BADA35 /* ObjCCBOR.h in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -82,10 +87,12 @@
 /* Begin PBXFileReference section */
 		3720B709245186FB005B9C8D /* NSObject+ObjCCBOR.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+ObjCCBOR.m"; sourceTree = "<group>"; };
 		3720B70A245186FB005B9C8D /* cbortojson_nsstring.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = cbortojson_nsstring.m; sourceTree = "<group>"; };
-		3720B70B245186FB005B9C8D /* NSData+ObjCCBOR.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+ObjCCBOR.m"; sourceTree = "<group>"; };
 		3720B70C245186FB005B9C8D /* NSObject+ObjCCBOR.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+ObjCCBOR.h"; sourceTree = "<group>"; };
 		3720B70D245186FB005B9C8D /* NSData+ObjCCBOR.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+ObjCCBOR.h"; sourceTree = "<group>"; };
 		3720B70E245186FB005B9C8D /* cbortojson_nsstring.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cbortojson_nsstring.h; sourceTree = "<group>"; };
+		37388126245AC82200BADA35 /* CBORRepresentable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBORRepresentable.h; sourceTree = "<group>"; };
+		37388128245ACE4900BADA35 /* TestHelpers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestHelpers.m; sourceTree = "<group>"; };
+		3738812F245C86EB00BADA35 /* ObjCCBOR.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCCBOR.h; sourceTree = "<group>"; };
 		3762E82F240FF98700D823DC /* ObjCCBORTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ObjCCBORTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3762E836240FF98700D823DC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3762E840240FFAA100D823DC /* EncodingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EncodingTests.m; sourceTree = "<group>"; };
@@ -110,8 +117,8 @@
 		D26CE649244FCA9400B8A91A /* NSData+ObjCCBOR.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+ObjCCBOR.m"; sourceTree = "<group>"; };
 		D26CE65524502BF300B8A91A /* libtinycbor.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libtinycbor.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		D26CE68224502F5E00B8A91A /* libObjCCBOR.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libObjCCBOR.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		D26CE68424502F5E00B8A91A /* ObjCCBOR.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCCBOR.h; sourceTree = "<group>"; };
-		D26CE68524502F5E00B8A91A /* ObjCCBOR.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjCCBOR.m; sourceTree = "<group>"; };
+		D26CE68424502F5E00B8A91A /* CBOR.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CBOR.h; sourceTree = "<group>"; };
+		D26CE68524502F5E00B8A91A /* CBOR.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CBOR.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -148,7 +155,6 @@
 				3720B70A245186FB005B9C8D /* cbortojson_nsstring.m */,
 				3720B70D245186FB005B9C8D /* NSData+ObjCCBOR.h */,
 				D26CE649244FCA9400B8A91A /* NSData+ObjCCBOR.m */,
-				3720B70B245186FB005B9C8D /* NSData+ObjCCBOR.m */,
 				3720B70C245186FB005B9C8D /* NSObject+ObjCCBOR.h */,
 				3720B709245186FB005B9C8D /* NSObject+ObjCCBOR.m */,
 			);
@@ -182,6 +188,7 @@
 				3762E841240FFAA100D823DC /* DecodingTests.m */,
 				3762E840240FFAA100D823DC /* EncodingTests.m */,
 				3762E842240FFAA100D823DC /* TestsHelpers.h */,
+				37388128245ACE4900BADA35 /* TestHelpers.m */,
 				3762E836240FF98700D823DC /* Info.plist */,
 			);
 			path = ObjCCBORTests;
@@ -229,8 +236,10 @@
 			isa = PBXGroup;
 			children = (
 				3720B708245186FB005B9C8D /* Private */,
-				D26CE68424502F5E00B8A91A /* ObjCCBOR.h */,
-				D26CE68524502F5E00B8A91A /* ObjCCBOR.m */,
+				D26CE68424502F5E00B8A91A /* CBOR.h */,
+				D26CE68524502F5E00B8A91A /* CBOR.m */,
+				37388126245AC82200BADA35 /* CBORRepresentable.h */,
+				3738812F245C86EB00BADA35 /* ObjCCBOR.h */,
 			);
 			path = ObjCCBOR;
 			sourceTree = "<group>";
@@ -347,6 +356,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3762E843240FFAA100D823DC /* EncodingTests.m in Sources */,
+				37388129245ACE4900BADA35 /* TestHelpers.m in Sources */,
 				3762E844240FFAA100D823DC /* DecodingTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -375,7 +385,7 @@
 				D26CE68C24502F8300B8A91A /* NSData+ObjCCBOR.m in Sources */,
 				3720B70F245186FB005B9C8D /* NSObject+ObjCCBOR.m in Sources */,
 				3720B710245186FB005B9C8D /* cbortojson_nsstring.m in Sources */,
-				D26CE68624502F5E00B8A91A /* ObjCCBOR.m in Sources */,
+				D26CE68624502F5E00B8A91A /* CBOR.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -597,6 +607,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -609,6 +620,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ObjCCBOR/CBOR.h
+++ b/ObjCCBOR/CBOR.h
@@ -1,0 +1,44 @@
+//
+//  CBOR.h
+//  ObjCCBOR
+//
+//  Created by Hamilton Chapman on 20/02/2020.
+//  Copyright © 2020 Ditto. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CBOR : NSObject
+
+/**
+ Decode CBOR data into its corresponding NSObject type. Note that
+ this library supports primitives so the resulting type could be any
+ of `NSDictionary`, `NSArray`, `NSString`, `NSNumber`, `NSNull` or
+ `NSData`.
+
+ @param data The data to be decoded.
+ @param error An optional error out parameter. If not `NULL`, then
+ an error object will be written to this parameter should decoding fail.
+ @returns Returns one of `NSDictionary`, `NSArray`, `NSString`,
+ `NSNumber`, `NSNull` or `NSData`. Will return `nil` if the decoding
+ fails.
+ */
++ (nullable id)decodeData:(NSData *)data error:(NSError * _Nullable __autoreleasing *)error;
+
+/**
+ Encodes an NSObject into its CBOR representation. Note that `object`
+ may only be one of `NSDictionary`, `NSArray`, `NSString`, `NSNumber`,
+ `NSNull`, `NSData` or their mutable variants where appropriate.
+
+ @param object The object to be encoded.
+ @param error An optional error out parameter. If not `NULL`, then
+ an error object will be written to this parameter should encoding fail.
+ @returns Returns the encoded data or `nil` if the encoding fails.
+ */
++ (NSData *)encodeObject:(NSObject *)object error:(NSError * _Nullable __autoreleasing *)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ObjCCBOR/CBOR.m
+++ b/ObjCCBOR/CBOR.m
@@ -1,18 +1,19 @@
 //
-//  ObjCCBOR.m
+//  CBOR.m
 //  ObjCCBOR
 //
 //  Created by Hamilton Chapman on 20/02/2020.
 //  Copyright © 2020 Ditto. All rights reserved.
 //
 
-#import "ObjCCBOR.h"
+#import "CBOR.h"
+
 #import "NSData+ObjCCBOR.h"
 #import "NSObject+ObjCCBOR.h"
 
-@implementation ObjCCBOR
+@implementation CBOR
 
-+ (nullable id)decode:(NSData *)data error:(NSError * _Nullable __autoreleasing *)error {
++ (nullable id)decodeData:(NSData *)data error:(NSError * _Nullable __autoreleasing *)error {
     NSError *err = nil;
     id decoded = [data ds_decodeCborError:&err];
     if (error && err != nil) {
@@ -21,7 +22,7 @@
     return decoded;
 }
 
-+ (NSData *)encode:(NSObject *)object error:(NSError * _Nullable __autoreleasing *)error {
++ (NSData *)encodeObject:(NSObject *)object error:(NSError * _Nullable __autoreleasing *)error {
     NSError *err = nil;
     NSData *encoded = [object ds_cborEncodedObjectError:&err];
     if (error && err != nil) {

--- a/ObjCCBOR/CBORRepresentable.h
+++ b/ObjCCBOR/CBORRepresentable.h
@@ -1,0 +1,19 @@
+//
+//  CBORRepresentable.h
+//  ObjCCBOR
+//
+//  Created by Hamilton Chapman on 30/04/2020.
+//  Copyright © 2020 Dash. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol CBORRepresentable
+
+- (nullable NSObject *)CBORRepresentation;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ObjCCBOR/ObjCCBOR.h
+++ b/ObjCCBOR/ObjCCBOR.h
@@ -2,43 +2,11 @@
 //  ObjCCBOR.h
 //  ObjCCBOR
 //
-//  Created by Hamilton Chapman on 20/02/2020.
-//  Copyright © 2020 Ditto. All rights reserved.
+//  Created by Hamilton Chapman on 01/05/2020.
+//  Copyright © 2020 Dash. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
 
-NS_ASSUME_NONNULL_BEGIN
-
-@interface ObjCCBOR : NSObject
-
-/**
- Decode CBOR data into its corresponding NSObject type. Note that
- this library supports primitives so the resulting type could be any
- of `NSDictionary`, `NSArray`, `NSString`, `NSNumber`, `NSNull` or
- `NSData`.
-
- @param data The data to be decoded.
- @param error An optional error out parameter. If not `NULL`, then
- an error object will be written to this parameter should decoding fail.
- @returns Returns one of `NSDictionary`, `NSArray`, `NSString`,
- `NSNumber`, `NSNull` or `NSData`. Will return `nil` if the decoding
- fails.
- */
-+ (nullable id)decode:(NSData *)data error:(NSError * _Nullable __autoreleasing *)error;
-
-/**
- Encodes an NSObject into its CBOR representation. Note that `object`
- may only be one of `NSDictionary`, `NSArray`, `NSString`, `NSNumber`,
- `NSNull`, `NSData` or their mutable variants where appropriate.
-
- @param object The object to be encoded.
- @param error An optional error out parameter. If not `NULL`, then
- an error object will be written to this parameter should encoding fail.
- @returns Returns the encoded data or `nil` if the encoding fails.
- */
-+ (NSData *)encode:(NSObject *)object error:(NSError * _Nullable __autoreleasing *)error;
-
-@end
-
-NS_ASSUME_NONNULL_END
+#import <ObjCCBOR/CBOR.h>
+#import <ObjCCBOR/CBORRepresentable.h>

--- a/ObjCCBOR/Private/NSData+ObjCCBOR.m
+++ b/ObjCCBOR/Private/NSData+ObjCCBOR.m
@@ -59,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         return nil;
     }
-    
+
     NSData *jsonData = [jsonString dataUsingEncoding:NSUTF8StringEncoding];
     NSError *jsonError = nil;
     id parsedData = [NSJSONSerialization JSONObjectWithData:jsonData
@@ -118,17 +118,17 @@ NS_ASSUME_NONNULL_BEGIN
     if (!data) {
         return string;
     }
-    
+
     return data;
 }
 
 - (BOOL)shouldConvertObject:(id)object {
     if ([object isKindOfClass:NSString.class] &&
         [object hasPrefix:DSCborBase64DataMarker]) {
-        
+
         return YES;
     }
-    
+
     return NO;
 }
 

--- a/ObjCCBOR/Private/cbortojson_nsstring.h
+++ b/ObjCCBOR/Private/cbortojson_nsstring.h
@@ -32,7 +32,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-    
+
 extern NSString * const DSCborBase64DataMarker;
 
 CBOR_API CborError cbor_value_to_json_advance_nsstring(NSMutableString *out, CborValue *value, int flags);

--- a/ObjCCBORTests/DecodingTests.m
+++ b/ObjCCBORTests/DecodingTests.m
@@ -21,7 +21,7 @@
 - (void)testArrayDecoding {
     NSData *data = DATABYTES(0x82, 0x01, 0x02);
     NSError *error = nil;
-    id decoded = [ObjCCBOR decode:data error:&error];
+    id decoded = [CBOR decodeData:data error:&error];
     id result = @[ @1, @2 ];
     XCTAssertEqualObjects(decoded, result);
     XCTAssertNil(error);
@@ -32,11 +32,11 @@
                                                    @"£test£": @"¡€#¢•©˙∆åßƒ∫~µç≈Ω"
                                                    };
     NSError *error = nil;
-    NSData *encoded = [ObjCCBOR encode:dict error:&error];
+    NSData *encoded = [CBOR encodeObject:dict error:&error];
     XCTAssertNotNil(encoded);
     XCTAssertNil(error);
 
-    id decoded = [ObjCCBOR decode:encoded error:&error];
+    id decoded = [CBOR decodeData:encoded error:&error];
     XCTAssertEqualObjects(decoded, dict);
     XCTAssertNil(error);
 }
@@ -44,7 +44,7 @@
 - (void)testDictionaryDecoding {
     NSData *data = DATABYTES(0xA1, 0x63, 0x61, 0x62, 0x63, 0x18, 0x2A);
     NSError *error = nil;
-    id decoded = [ObjCCBOR decode:data error:&error];
+    id decoded = [CBOR decodeData:data error:&error];
     id result = @{ @"abc" : @42 };
     XCTAssertEqualObjects(decoded, result);
     XCTAssertNil(error);
@@ -53,7 +53,7 @@
 - (void)testEmptyDataDecoding {
     NSData *data = DATABYTES();
     NSError *error = nil;
-    id decoded = [ObjCCBOR decode:data error:&error];
+    id decoded = [CBOR decodeData:data error:&error];
     XCTAssertNil(decoded);
     XCTAssertNotNil(error);
 }
@@ -65,11 +65,11 @@
         @"other type key" : @[ @1, @2 ],
     };
     NSError *error = nil;
-    NSData *encoded = [ObjCCBOR encode:json error:&error];
+    NSData *encoded = [CBOR encodeObject:json error:&error];
     XCTAssertNotNil(encoded);
     XCTAssertNil(error);
 
-    id decoded = [ObjCCBOR decode:encoded error:&error];
+    id decoded = [CBOR decodeData:encoded error:&error];
     XCTAssertEqualObjects(decoded, json);
     XCTAssertNil(error);
 }
@@ -77,11 +77,11 @@
 - (void)testEncodingAndDecodingLargeString {
     NSString *str = [@"" stringByPaddingToLength:50000 withString: @"a" startingAtIndex:0];
     NSError *error = nil;
-    NSData *encoded = [ObjCCBOR encode:str error:&error];
+    NSData *encoded = [CBOR encodeObject:str error:&error];
     XCTAssertNotNil(encoded);
     XCTAssertNil(error);
 
-    id decoded = [ObjCCBOR decode:encoded error:&error];
+    id decoded = [CBOR decodeData:encoded error:&error];
     XCTAssertEqual(((NSString *)decoded).length, 50000);
     XCTAssertEqualObjects(decoded, str);
     XCTAssertNil(error);
@@ -97,11 +97,11 @@
     }
 
     NSError *error = nil;
-    NSData *encoded = [ObjCCBOR encode:dict error:&error];
+    NSData *encoded = [CBOR encodeObject:dict error:&error];
     XCTAssertNotNil(encoded);
     XCTAssertNil(error);
 
-    NSDictionary *decoded = [ObjCCBOR decode:encoded error:&error];
+    NSDictionary *decoded = [CBOR decodeData:encoded error:&error];
     XCTAssertNil(error);
 
     NSString *aString = (NSString *)decoded[@"a"];
@@ -122,7 +122,7 @@
 
     NSDictionary *d = @{ @"data" : data };
     NSError *error = nil;
-    id decoded = [ObjCCBOR decode:encoded error:&error];
+    id decoded = [CBOR decodeData:encoded error:&error];
     XCTAssertEqualObjects(decoded, d);
     XCTAssertNil(error);
 }
@@ -143,11 +143,11 @@
     };
 
     NSError *error = nil;
-    NSData *encoded = [ObjCCBOR encode:dict error:&error];
+    NSData *encoded = [CBOR encodeObject:dict error:&error];
     XCTAssertNotNil(encoded);
     XCTAssertNil(error);
 
-    id decoded = [ObjCCBOR decode:encoded error:&error];
+    id decoded = [CBOR decodeData:encoded error:&error];
     XCTAssertEqualObjects(decoded, dict);
     XCTAssertNil(error);
 }
@@ -155,11 +155,11 @@
 - (void)testEncodingAndDecodingASimpleString {
     NSString *str = @"a";
     NSError *error = nil;
-    NSData *encoded = [ObjCCBOR encode:str error:&error];
+    NSData *encoded = [CBOR encodeObject:str error:&error];
     XCTAssertNotNil(encoded);
     XCTAssertNil(error);
 
-    id decoded = [ObjCCBOR decode:encoded error:&error];
+    id decoded = [CBOR decodeData:encoded error:&error];
     XCTAssertEqualObjects(decoded, str);
     XCTAssertNil(error);
 }
@@ -184,11 +184,11 @@
     };
 
     NSError *error = nil;
-    NSData *encoded = [ObjCCBOR encode:dict error:&error];
+    NSData *encoded = [CBOR encodeObject:dict error:&error];
     XCTAssertNotNil(encoded);
     XCTAssertNil(error);
 
-    id decoded = [ObjCCBOR decode:encoded error:&error];
+    id decoded = [CBOR decodeData:encoded error:&error];
     XCTAssertEqualObjects(decoded, dict);
     XCTAssertNil(error);
 }

--- a/ObjCCBORTests/EncodingTests.m
+++ b/ObjCCBORTests/EncodingTests.m
@@ -15,11 +15,12 @@
 //  limitations under the License.
 //
 
+#import <XCTest/XCTest.h>
+
+#import <ObjCCBOR/CBORRepresentable.h>
 #import <ObjCCBOR/ObjCCBOR.h>
 
 #import "TestsHelpers.h"
-
-@import XCTest;
 
 @interface DSCborEncodingTests : XCTestCase
 
@@ -29,40 +30,40 @@
 
 - (void)testEncodeInts {
     for (uint8_t i = 0; i < 24; i++) {
-        XCTAssertEqualObjects([ObjCCBOR encode:@(i) error:nil],
+        XCTAssertEqualObjects([CBOR encodeObject:@(i) error:nil],
                               DATABYTES(i));
     }
-    
-    XCTAssertEqualObjects([ObjCCBOR encode:@(-1) error:nil],
+
+    XCTAssertEqualObjects([CBOR encodeObject:@(-1) error:nil],
                           DATABYTES(0x20));
-    XCTAssertEqualObjects([ObjCCBOR encode:@(-10) error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:@(-10) error:nil],
                           DATABYTES(0x29));
-    XCTAssertEqualObjects([ObjCCBOR encode:@(-24) error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:@(-24) error:nil],
                           DATABYTES(0x37));
-    XCTAssertEqualObjects([ObjCCBOR encode:@(-25) error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:@(-25) error:nil],
                           DATABYTES(0x38, 24));
-    XCTAssertEqualObjects([ObjCCBOR encode:@1000000 error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:@1000000 error:nil],
                           DATABYTES(0x1a, 0x00, 0x0f, 0x42, 0x40));
-    XCTAssertEqualObjects([ObjCCBOR encode:@4294967295 error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:@4294967295 error:nil],
                           DATABYTES(0x1a, 0xff, 0xff, 0xff, 0xff));
-    XCTAssertEqualObjects([ObjCCBOR encode:@1000000000000 error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:@1000000000000 error:nil],
                           DATABYTES(0x1b, 0x00, 0x00, 0x00, 0xe8, 0xd4, 0xa5, 0x10, 0x00));
 }
 
 - (void)testEncodeStrings {
-    XCTAssertEqualObjects([ObjCCBOR encode:@"" error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:@"" error:nil],
                           DATABYTES(0x60));
-    XCTAssertEqualObjects([ObjCCBOR encode:@"a" error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:@"a" error:nil],
                           DATABYTES(0x61, 0x61));
-    XCTAssertEqualObjects([ObjCCBOR encode:@"B" error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:@"B" error:nil],
                           DATABYTES(0x61, 0x42));
-    XCTAssertEqualObjects([ObjCCBOR encode:@"ABC" error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:@"ABC" error:nil],
                           DATABYTES(0x63, 0x41, 0x42, 0x43));
-    XCTAssertEqualObjects([ObjCCBOR encode:@"IETF" error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:@"IETF" error:nil],
                           DATABYTES(0x64, 0x49, 0x45, 0x54, 0x46));
-    XCTAssertEqualObjects([ObjCCBOR encode:@"今日は" error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:@"今日は" error:nil],
                           DATABYTES(0x69, 0xE4, 0xBB, 0x8A, 0xE6, 0x97, 0xA5, 0xE3, 0x81, 0xAF));
-    XCTAssertEqualObjects([ObjCCBOR encode:@"♨️français;日本語！Longer text\n with break?"
+    XCTAssertEqualObjects([CBOR encodeObject:@"♨️français;日本語！Longer text\n with break?"
                                      error:nil],
                           DATABYTES(0x78, 0x34, 0xe2, 0x99, 0xa8, 0xef, 0xb8, 0x8f, 0x66, 0x72,
                                     0x61, 0x6e, 0xc3, 0xa7, 0x61, 0x69, 0x73, 0x3b, 0xe6, 0x97,
@@ -70,109 +71,109 @@
                                     0x4c, 0x6f, 0x6e, 0x67, 0x65, 0x72, 0x20, 0x74, 0x65, 0x78,
                                     0x74, 0x0a, 0x20, 0x77, 0x69, 0x74, 0x68, 0x20, 0x62, 0x72,
                                     0x65, 0x61, 0x6b, 0x3f));
-    XCTAssertEqualObjects([ObjCCBOR encode:@"\"\\" error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:@"\"\\" error:nil],
                           DATABYTES(0x62, 0x22, 0x5c));
-    XCTAssertEqualObjects([ObjCCBOR encode:@"\u6C34" error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:@"\u6C34" error:nil],
                           DATABYTES(0x63, 0xe6, 0xb0, 0xb4));
-    XCTAssertEqualObjects([ObjCCBOR encode:@"水" error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:@"水" error:nil],
                           DATABYTES(0x63, 0xe6, 0xb0, 0xb4));
-    XCTAssertEqualObjects([ObjCCBOR encode:@"\u00fc" error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:@"\u00fc" error:nil],
                           DATABYTES(0x62, 0xc3, 0xbc));
-    XCTAssertEqualObjects([ObjCCBOR encode:@"abc\n123" error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:@"abc\n123" error:nil],
                           DATABYTES(0x67, 0x61, 0x62, 0x63, 0x0a, 0x31, 0x32, 0x33));
 }
 
 - (void)testEncodeSimple {
-    XCTAssertEqualObjects([ObjCCBOR encode:@NO error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:@NO error:nil],
                           DATABYTES(0xf4));
-    XCTAssertEqualObjects([ObjCCBOR encode:@YES error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:@YES error:nil],
                           DATABYTES(0xf5));
-    XCTAssertEqualObjects([ObjCCBOR encode:[NSNull null] error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:[NSNull null] error:nil],
                           DATABYTES(0xf6));
 }
 
 - (void)testEncodeFloats {
     // The following tests are modifications of examples of Float16 in the RFC
-    XCTAssertEqualObjects([ObjCCBOR encode:DSFLOAT(0.0) error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:DSFLOAT(0.0) error:nil],
                           DATABYTES(0xfa, 0x00, 0x00, 0x00, 0x00));
-    XCTAssertEqualObjects([ObjCCBOR encode:DSFLOAT(-0.0) error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:DSFLOAT(-0.0) error:nil],
                           DATABYTES(0xfa, 0x80, 0x00, 0x00, 0x00));
-    XCTAssertEqualObjects([ObjCCBOR encode:DSFLOAT(1.0) error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:DSFLOAT(1.0) error:nil],
                           DATABYTES(0xfa, 0x3f, 0x80, 0x00, 0x00));
-    XCTAssertEqualObjects([ObjCCBOR encode:DSFLOAT(1.5) error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:DSFLOAT(1.5) error:nil],
                           DATABYTES(0xfa, 0x3f, 0xc0, 0x00, 0x00));
-    XCTAssertEqualObjects([ObjCCBOR encode:DSFLOAT(65504.0) error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:DSFLOAT(65504.0) error:nil],
                           DATABYTES(0xfa, 0x47, 0x7f, 0xe0, 0x00));
-    
+
     // The following are seen as Float32s in the RFC
-    XCTAssertEqualObjects([ObjCCBOR encode:DSFLOAT(100000.0) error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:DSFLOAT(100000.0) error:nil],
                           DATABYTES(0xfa, 0x47, 0xc3, 0x50, 0x00));
-    XCTAssertEqualObjects([ObjCCBOR encode:DSFLOAT(3.4028234663852886e+38) error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:DSFLOAT(3.4028234663852886e+38) error:nil],
                           DATABYTES(0xfa, 0x7f, 0x7f, 0xff, 0xff));
-    
+
     // The following are seen as Doubles in the RFC
-    XCTAssertEqualObjects([ObjCCBOR encode:DSDOUBLE(1.1) error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:DSDOUBLE(1.1) error:nil],
                           DATABYTES(0xfb, 0x3f, 0xf1, 0x99, 0x99, 0x99, 0x99, 0x99, 0x9a));
-    XCTAssertEqualObjects([ObjCCBOR encode:DSDOUBLE(-4.1) error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:DSDOUBLE(-4.1) error:nil],
                           DATABYTES(0xfb, 0xc0, 0x10, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66));
-    XCTAssertEqualObjects([ObjCCBOR encode:DSDOUBLE(1.0e+300) error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:DSDOUBLE(1.0e+300) error:nil],
                           DATABYTES(0xfb, 0x7e, 0x37, 0xe4, 0x3c, 0x88, 0x00, 0x75, 0x9c));
-    XCTAssertEqualObjects([ObjCCBOR encode:DSDOUBLE(5.960464477539063e-8) error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:DSDOUBLE(5.960464477539063e-8) error:nil],
                           DATABYTES(0xfb, 0x3e, 0x70, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00));
-    
+
     // Special values
-    XCTAssertEqualObjects([ObjCCBOR encode:DSDOUBLE(INFINITY) error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:DSDOUBLE(INFINITY) error:nil],
                           DATABYTES(0xfb, 0x7f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00));
-    XCTAssertEqualObjects([ObjCCBOR encode:DSDOUBLE(-INFINITY) error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:DSDOUBLE(-INFINITY) error:nil],
                           DATABYTES(0xfb, 0xff, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00));
-    XCTAssertEqualObjects([ObjCCBOR encode:DSDOUBLE(NAN) error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:DSDOUBLE(NAN) error:nil],
                           DATABYTES(0xfb, 0x7f, 0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00));
-    
+
     // These tests are failed because NSNumber internally stores INFINITY
     // as a double despite of numberWithFloat:
-    //    XCTAssertEqualObjects([ObjCCBOR encode:DSFLOAT(INFINITY) error:nil],
+    //    XCTAssertEqualObjects([CBOR encodeObject:DSFLOAT(INFINITY) error:nil],
     //                          DATABYTES(0xfa, 0x7f, 0x80, 0x00, 0x00));
-    //    XCTAssertEqualObjects([ObjCCBOR encode:DSFLOAT(-INFINITY) error:nil],
+    //    XCTAssertEqualObjects([CBOR encodeObject:DSFLOAT(-INFINITY) error:nil],
     //                          DATABYTES(0xfa, 0xff, 0x80, 0x00, 0x00));
-    //    XCTAssertEqualObjects([ObjCCBOR encode:DSFLOAT(NAN) error:nil],
+    //    XCTAssertEqualObjects([CBOR encodeObject:DSFLOAT(NAN) error:nil],
     //                          DATABYTES(0xfa, 0x7f, 0xc0, 0x00, 0x00));
 
-    XCTAssertEqualObjects([ObjCCBOR encode:DSDOUBLE(INFINITY) error:nil],
-                          [ObjCCBOR encode:DSFLOAT(INFINITY) error:nil]);
-    XCTAssertEqualObjects([ObjCCBOR encode:DSDOUBLE(-INFINITY) error:nil],
-                          [ObjCCBOR encode:DSFLOAT(-INFINITY) error:nil]);
-    XCTAssertEqualObjects([ObjCCBOR encode:DSDOUBLE(NAN) error:nil],
-                          [ObjCCBOR encode:DSFLOAT(NAN) error:nil]);
+    XCTAssertEqualObjects([CBOR encodeObject:DSDOUBLE(INFINITY) error:nil],
+                          [CBOR encodeObject:DSFLOAT(INFINITY) error:nil]);
+    XCTAssertEqualObjects([CBOR encodeObject:DSDOUBLE(-INFINITY) error:nil],
+                          [CBOR encodeObject:DSFLOAT(-INFINITY) error:nil]);
+    XCTAssertEqualObjects([CBOR encodeObject:DSDOUBLE(NAN) error:nil],
+                          [CBOR encodeObject:DSFLOAT(NAN) error:nil]);
 }
 
 - (void)testEncodeArrays {
-    XCTAssertEqualObjects([ObjCCBOR encode:@[] error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:@[] error:nil],
                           DATABYTES(0x80));
 
-    XCTAssertEqualObjects([ObjCCBOR encode:(@[@1, @2, @3]) error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:(@[@1, @2, @3]) error:nil],
                           DATABYTES(0x83, 0x01, 0x02, 0x03));
 
-    XCTAssertEqualObjects([ObjCCBOR encode:(@[ @[ @1 ], @[ @2, @3 ], @[ @4, @5 ] ]) error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:(@[ @[ @1 ], @[ @2, @3 ], @[ @4, @5 ] ]) error:nil],
                           DATABYTES(0x83, 0x81, 0x01, 0x82, 0x02, 0x03, 0x82, 0x04, 0x05));
-    
+
     NSMutableArray *ma = [NSMutableArray array];
     for (NSInteger i = 1; i <= 25; i++) {
         [ma addObject:@(i)];
     }
-    XCTAssertEqualObjects([ObjCCBOR encode:ma error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:ma error:nil],
                           DATABYTES(0x98, 0x19, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
                                     0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12,
                                     0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x18, 0x18, 0x19));
 }
 
 - (void)testEncodeDictionaries {
-    XCTAssertEqualObjects([ObjCCBOR encode:@{} error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:@{} error:nil],
                           DATABYTES(0xa0));
 
-    XCTAssertEqualObjects([ObjCCBOR encode:(@{ @"x": @2, @"y": @4 }) error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:(@{ @"x": @2, @"y": @4 }) error:nil],
                           DATABYTES(0xa2, 0x61, 0x78, 0x02, 0x61, 0x79, 0x04));
 
-    XCTAssertEqualObjects([ObjCCBOR encode:(@{ @"a": @[ @1 ], @"b": @[ @2, @3 ] }) error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:(@{ @"a": @[ @1 ], @"b": @[ @2, @3 ] }) error:nil],
                           DATABYTES(0xa2, 0x61, 0x61, 0x81, 0x01, 0x61, 0x62, 0x82, 0x02, 0x03));
 }
 
@@ -180,9 +181,44 @@
     NSString *dataString = @"abc";
     NSData *data = [dataString dataUsingEncoding:NSUTF8StringEncoding];
 
-    XCTAssertEqualObjects([ObjCCBOR encode:(@{@"data": data}) error:nil],
+    XCTAssertEqualObjects([CBOR encodeObject:(@{@"data": data}) error:nil],
                           DATABYTES(0xa1, 0x64, 0x64, 0x61, 0x74, 0x61, 0x43, 0x61, 0x62, 0x63));
 }
 
-@end
+- (void)testEncodeCBORRepresentable {
+    NSString *name = @"Sarah";
+    NSDictionary *straightDict = @{@"the_name": name};
 
+    NSData *expectedCBORBytes = DATABYTES(0xa1, 0x68, 0x74, 0x68, 0x65, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x65,
+                                          0x53, 0x61, 0x72, 0x61, 0x68);
+
+    NSData *encodedDict = [CBOR encodeObject:straightDict error:nil];
+    XCTAssertEqualObjects(encodedDict, expectedCBORBytes);
+
+    MyCBORCompatibleObject *protocolConformingObj = [[MyCBORCompatibleObject alloc] initWithName:name];
+
+    NSData *encodedConformingObj = [CBOR encodeObject:protocolConformingObj error:nil];
+    XCTAssertEqualObjects(encodedConformingObj, expectedCBORBytes);
+    XCTAssertEqualObjects(encodedConformingObj, encodedDict);
+}
+
+- (void)testEncodeNestedCBORRepresentable {
+    NSString *name = @"Sarah";
+    NSDictionary *straightDict = @{@"outer": @{@"the_name": name}};
+
+    NSData *expectedCBORBytes = DATABYTES(0xa1, 0x65, 0x6f, 0x75, 0x74, 0x65, 0x72, 0xa1, 0x68, 0x74, 0x68,
+                                          0x65, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x65, 0x53, 0x61, 0x72, 0x61,
+                                          0x68);
+
+    NSData *encodedDict = [CBOR encodeObject:straightDict error:nil];
+    XCTAssertEqualObjects(encodedDict, expectedCBORBytes);
+
+    MyCBORCompatibleObject *protocolConformingObj = [[MyCBORCompatibleObject alloc] initWithName:name];
+    NSDictionary *nestedObj = @{@"outer": protocolConformingObj};
+
+    NSData *encodedNestedObj = [CBOR encodeObject:nestedObj error:nil];
+    XCTAssertEqualObjects(encodedNestedObj, expectedCBORBytes);
+    XCTAssertEqualObjects(encodedNestedObj, encodedDict);
+}
+
+@end

--- a/ObjCCBORTests/TestHelpers.m
+++ b/ObjCCBORTests/TestHelpers.m
@@ -1,0 +1,27 @@
+//
+//  TestHelpers.m
+//  ObjCCBORTests
+//
+//  Created by Hamilton Chapman on 30/04/2020.
+//  Copyright © 2020 Dash. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "TestsHelpers.h"
+
+@implementation MyCBORCompatibleObject
+
+- (instancetype)initWithName:(NSString *)name {
+    self = [super init];
+    if (self != nil) {
+        _name = name;
+    }
+    return self;
+}
+
+- (NSDictionary<NSString *, id> *)CBORRepresentation {
+    return @{@"the_name": self.name};
+}
+
+@end

--- a/ObjCCBORTests/TestsHelpers.h
+++ b/ObjCCBORTests/TestsHelpers.h
@@ -6,6 +6,8 @@
 //  Copyright © 2019 Andrew Podkovyrin. All rights reserved.
 //
 
+#import <ObjCCBOR/CBORRepresentable.h>
+
 #ifndef TestsHelpers_h
 #define TestsHelpers_h
 
@@ -17,5 +19,10 @@ data; \
 
 #define DSFLOAT(A) [NSNumber numberWithFloat:A]
 #define DSDOUBLE(A) [NSNumber numberWithDouble:A]
+
+@interface MyCBORCompatibleObject : NSObject <CBORRepresentable>
+- (instancetype)initWithName:(NSString *)name;
+@property (nonatomic, readonly) NSString *name;
+@end
 
 #endif /* TestsHelpers_h */


### PR DESCRIPTION
Solution: Add a `CBORRepresentable` protocol, which has a single required function named `getCBORRepresentation`. This must return an `NSObject *`. This returned object is what is then used to try and encode the object into CBOR.

---

~~Gonna add a little test for this but asking for review now because it's just a small change and the test isn't the bit I want input/feedback 😁~~