### PR TITLE
🙉 Ignore code coverage symbols

### DIFF
--- a/Scripts/ObjCCBORAssertAllSymbolsAreMangled.sh
+++ b/Scripts/ObjCCBORAssertAllSymbolsAreMangled.sh
@@ -12,6 +12,7 @@ nm -gUPA "$BUILT_PRODUCTS_DIR/libtinycbor.a" | cut -d ' ' -f 2 > "$TARGET_TEMP_D
 grep -vf "$TARGET_TEMP_DIR/tinycbor-symbols.txt" "$TARGET_TEMP_DIR/ObjCCBOR-symbols.txt" \
     | grep -v -E "___block_descriptor_" \
     | grep -v -E "___copy_helper_" \
+    | grep -v -E "___covrec_" \
     | grep -v -E "___destroy_helper_" \
     > "$TARGET_TEMP_DIR/ObjCCBOR-relevant-symbols.txt" \
     ;


### PR DESCRIPTION
These symbols apparently get included when an Xcode scheme or test plan has code coverage enabled.

> The following symbols seem not to be mangled. Please add them to the
> 
> SYMBOLS_TO_MANGLE array in Scripts/ObjCCBORGenerateManglingHeader.sh.
> 
> __covrec_1073EF926E5E2161
> __covrec_11DCB55DDFFEF8FE
> __covrec_121E5CAE3E0DD8FE
> __covrec_144FE44EBC0EF479u
> __covrec_14CD66254597CB6E
> __covrec_1523768B06BE4B21u
> __covrec_15434E3CB32C8E21
> __covrec_1589C84121533B89
> __covrec_176840999046FD09
> __covrec_19DC3C9C7939B86D
> __covrec_1A1D712F8CF0B7FDu
> __covrec_1A2CD87CE7AD0D5A
> __covrec_1AF2C7A43E16456D
> __covrec_1CBB847EB5BF584C
> __covrec_1DE500A35F1FF15Cu
> __covrec_1F17B04B30E0098E
> __covrec_1F2C54209E8D621Du
>  ...

Added `__covrec_` to the list of ignored symbols. Confirmed this prevents build from failing when either a scheme or test plan has code coverage enabled.