### PR TITLE
 Fix `ObjCCBORAssertAllSymbolsAreMangled.sh` breaking if paths in `nm` output contain spaces

### DIFF
--- a/Scripts/ObjCCBORAssertAllSymbolsAreMangled.sh
+++ b/Scripts/ObjCCBORAssertAllSymbolsAreMangled.sh
@@ -6,8 +6,8 @@
 
 set -Euo pipefail
 
-nm -gUPA "$BUILT_PRODUCTS_DIR/libObjCCBOR.a" | cut -d ' ' -f 2 > "$TARGET_TEMP_DIR/ObjCCBOR-symbols.txt"
-nm -gUPA "$BUILT_PRODUCTS_DIR/libtinycbor.a" | cut -d ' ' -f 2 > "$TARGET_TEMP_DIR/tinycbor-symbols.txt"
+nm -gUPA "$BUILT_PRODUCTS_DIR/libObjCCBOR.a" | sed -e "s/.*\://" | cut -d ' ' -f 2 > "$TARGET_TEMP_DIR/ObjCCBOR-symbols.txt"
+nm -gUPA "$BUILT_PRODUCTS_DIR/libtinycbor.a" | sed -e "s/.*\://" | cut -d ' ' -f 2 > "$TARGET_TEMP_DIR/tinycbor-symbols.txt"
 
 grep -vf "$TARGET_TEMP_DIR/tinycbor-symbols.txt" "$TARGET_TEMP_DIR/ObjCCBOR-symbols.txt" \
     | grep -v -E "___block_descriptor_" \


### PR DESCRIPTION
The `ObjCCBORAssertAllSymbolsAreMangled.sh` breaks if `nm` spits out paths with spaces for `libObjCCBOR.a` and `libtinycbor.a`. Fix by removing that path prefix before passing the result to `cut` and extracting the symbol names.