### PR TITLE
Rework CBOR decoding to also support `NSData` values

### DIFF
--- a/ObjCCBOR/Private/NSData+ObjCCBOR.m
+++ b/ObjCCBOR/Private/NSData+ObjCCBOR.m
@@ -105,7 +105,7 @@ static id convertBase64DataToNSData(id object) {
         }
     }
 
-    // Nothing to do, rteturn object as-is.
+    // Nothing to do, return object as-is.
     return object;
 }
 

--- a/ObjCCBORTests/RoundtripTests.m
+++ b/ObjCCBORTests/RoundtripTests.m
@@ -201,6 +201,20 @@
     XCTAssertNil(error);
 }
 
+- (void)testRoundtripDataAtRoot {
+    NSString *dataString = @"abc";
+    NSData *data = [dataString dataUsingEncoding:NSUTF8StringEncoding];
+
+    NSError *error = nil;
+    NSData *encoded = [CBOR encodeObject:data error:&error];
+    XCTAssertNotNil(encoded);
+    XCTAssertNil(error);
+
+    id decoded = [CBOR decodeData:encoded error:&error];
+    XCTAssertEqualObjects(decoded, data);
+    XCTAssertNil(error);
+}
+
 - (void)testLargeNestedDictionaries {
     NSInteger numberOfEntries = 100;
     NSMutableDictionary *level1 = [[NSMutableDictionary alloc] initWithCapacity:numberOfEntries];


### PR DESCRIPTION
When decoding `NSData` values directly (i.e. not contained within an array or dictionary), the result is a base-64 encoded `NSString` with CBOR marker. This PR reworks the whole decoding code path to support `NSData` values and fix this issue. Also adds a rountrip test for this case. See corresponding Ditto issue for details: https://github.com/getditto/ditto/issues/7543.